### PR TITLE
Fix a could not open file error

### DIFF
--- a/R/hex-logo.R
+++ b/R/hex-logo.R
@@ -6,10 +6,13 @@ library(magick)
 # <div>Icons made by <a href="https://www.flaticon.com/free-icon/zoom_900930" title="phatplus">phatplus</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div>
 
 img <- image_read("figures/zoom.png")
+## Added the following line
+outfile <- tempfile(fileext=".png")
 
 sticker(img, package="iTIME",
         p_size=6, p_color = "#74bc1f", p_y = 1.1, p_x = 1.1,
         s_x=1, s_y=1, s_width=1.4, s_height=1.25,
         h_fill="white", h_color="#74bc1f", 
         url = "https://github.com/FridleyLab/iTIME", u_color = "#74bc1f", u_size = 1.3,
-        filename="figures/hex.png")
+        filename=outfile)
+##        filename="figures/hex.png")


### PR DESCRIPTION
filename="figures/hex.png")  was throwing the following error when the code was moved to a Linux (RedHat) server.
"Error in grid.newpage() : could not open file 'figures/hex.png'
Calls: runApp ... grid.draw.ggplot -> print -> print.ggplot -> grid.newpage
Execution halted"