### PR TITLE
Update hex-logo.R to eliminate an error

### DIFF
--- a/R/hex-logo.R
+++ b/R/hex-logo.R
@@ -7,9 +7,13 @@ library(magick)
 
 img <- image_read("figures/zoom.png")
 
+# the output should go to a temporary file
+outfile <- tempfile(fileext=".png")
+
 sticker(img, package="iTIME",
         p_size=6, p_color = "#74bc1f", p_y = 1.1, p_x = 1.1,
         s_x=1, s_y=1, s_width=1.4, s_height=1.25,
         h_fill="white", h_color="#74bc1f", 
         url = "https://github.com/FridleyLab/iTIME", u_color = "#74bc1f", u_size = 1.3,
-        filename="figures/hex.png")
+# This line throws an error starting the app  filename="figures/hex.png"
+       filename=outfile)


### PR DESCRIPTION
The code worked properly when running the app in the development computers.  Running the app on a Shiny server (Cent OS) throws an error regarding the size of the image.